### PR TITLE
chore: Default to tag latest when publishing docker

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -6,6 +6,7 @@ enablePlugins(AkkaserverlessPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"
 dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
+dockerUpdateLatest := true
 ThisBuild / dynverSeparator := "-"
 
 Compile / scalacOptions ++= Seq(


### PR DESCRIPTION
Based on note in forums: https://discuss.lightbend.com/t/sbt-deploy-does-not-automatically-tag-docker-image-with-latest/9252