### PR TITLE
Listen on 0.0.0.0 when running from sbt

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -9,6 +9,7 @@ dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 ThisBuild / dynverSeparator := "-"
 run / fork := true
+run / envVars += ("HOST", "0.0.0.0")
 
 Compile / scalacOptions ++= Seq(
   "-target:11",


### PR DESCRIPTION
Verified that it still listens to 127.0.0.1 from inside the docker container.

Similar to what was done for Java in https://github.com/lightbend/akkaserverless-java-sdk/pull/436